### PR TITLE
Add option to set open files limit

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -26,6 +26,7 @@
 # [*service_ensure*] The $service_ensure state
 # [*system_properties*] Defines a hash of system properties (-D) to be sent to java
 # [*non_standard_opts*] Defines the -X parameters to pass to java
+# [*max_file_limit*] Defines security limit for maximum open files for the Tomcat process
 #
 # === Requires
 # - The tomcat class
@@ -62,7 +63,8 @@ define tomcat::instance(
   $non_standard_opts       = ['mx1024M',
                               'ms256M',
                               'X:MaxPermSize=128M',
-                              'X:PermSize=64M']
+                              'X:PermSize=64M'],
+  $max_file_limit          = undef,
 ) {
   if ! defined(Class['tomcat']) {
     fail('You must include the tomcat base class before using any tomcat defined resources')

--- a/templates/default-tomcat-instance.erb
+++ b/templates/default-tomcat-instance.erb
@@ -23,3 +23,11 @@ JAVA_HOME=<%=java_home%>
 <% if @authbind %>
 AUTHBIND=yes
 <% end %>
+
+# If the application requires a large number of open files, the ulimits must be
+# set here as a workaround specifically for Tomcat applications. See following
+# link for documentation (https://ubuntuforums.org/showthread.php?t=1583041)
+<% if @max_file_limit %>
+ulimit -Hn <%=@max_file_limit%>
+ulimit -Sn <%=@max_file_limit%>
+<% end %>


### PR DESCRIPTION
This seems to be an unfortunate workaround that we need to do specifically for Tomcat, seemingly just adding lines to `limits.conf` for the tomcat user has no affect on the process itself, others have documented the same issues here;

https://www.malasuk.com/linux/increase-open-file-limit-tomcat-centos-7/
https://support.assetbank.co.uk/hc/en-gb/articles/115005041027-How-to-prevent-a-Too-many-open-files-error